### PR TITLE
Simplify event metadata/Quarto listing code and add developer documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,5 @@
 
 This repository contains the source code for the R.U.M. (R User Group at
 Manchester University) website.
+
+See the [Developer README](_README_dev.md) for developer information.

--- a/_README_dev.md
+++ b/_README_dev.md
@@ -1,19 +1,22 @@
 # Developer README
 
-## Event content pre- and post-migration to Quarto
+## Event content metadata
 
 Past events currently support two metadata styles:
 
 - Legacy pages (2023-04-27 to 2025-02-27) use `title` and `subtitle` display
-  strings.
-- Structured pages (2025-05-22 onward) use nested `event`, `talk`, `bio`, and
-  `content` metadata.
+  strings with a more free-format content body. These are pages that existed
+  prior to migrating the site to Quarto and adding more structured
+  metadata.
+- Newer pages (2025-05-22 onward) use nested `event`, `talk`, `bio`, and
+  `content` metadata. These are pages that were created after migrating the site
+  to Quarto and adding more structured metadata.
 
 Both styles are intentionally supported for backward compatibility.
 
 ## Creating a new event page
 
-To create a new page in `content/events/upcoming/`, use the following template:
+To create a new event page in `content/events/upcoming/`, use the following template:
 
 ```yaml
 ---
@@ -49,5 +52,85 @@ content:
 ```
 
 The `_event-detail-component.qmd` component renders event metadata, i.e. the
-summary/date/location, conditional Meetup text, talk title, abstract and speaker
-bio.
+talk title, summary, date, venue, URLs, abstract, speaker bio etc.
+
+***Tip:*** \
+You could use one of the newer (non-legacy) event pages as an example. These are
+listings created from 2025-05-22 onwards.
+
+Note that when there are no upcoming events to list, the
+`content/events/upcoming/` directory would be empty and the rendered site will
+display a message as configured in the metadata variable
+`'listing.template-params.empty-message'` (e.g. "We don't currently have any
+scheduled events ... please check back.")
+
+In this case, on running `quarto render` you will get a warning:
+
+```text
+WARN: The listing in 'content/events/index.qmd' using the following contents:
+- upcoming/*.qmd
+doesn't match any files or folders.
+```
+
+This is expected when there are no upcoming events to list. The warning has
+intentionally not been suppressed as it is truthful and could be helpful in the
+case of a genuine developer error. If there genuinely are no upcoming events,
+it can be ignored.
+
+### Filename and date formats
+
+Name the file `YYYY-MM-DD_short-description.qmd`, e.g.
+`2026-09-24_intro-to-tidymodels.qmd`. The date in the filename should match
+the `date` field in the YAML front matter, whilst the `event.date` field is
+formatted in a more human-friendly way as "Day-name Day Month, Year".
+
+### Moving an event to past
+
+When an event has taken place, simply move its `.qmd` file from
+`content/events/upcoming/` to `content/events/past/`. No other changes are
+needed; the listing pages pick up events by directory.
+
+## Managing team members
+
+### Adding a current team member
+
+Create a `.qmd` file in `content/team/current/` named after the person (e.g.
+`name.qmd`). Use the following template:
+
+```yaml
+---
+title: "Full Name"   # controls sort order
+format: html
+description: "Role and optional affiliation"
+date: "YYYY-MM-DD"   # date joined (or date entry first included)
+image: ../../../assets/img/team/filename.jpg
+about:
+  template: trestles
+  image: ../../../assets/img/team/filename.jpg
+  image-width: 12em
+  image-shape: round
+  image-alt: "Full Name"
+  image-title: "Full Name"
+---
+
+<!-- Current team member -->
+
+Bio text here.
+```
+
+Place the photo at `assets/img/team/filename.jpg`. If no photo is available,
+use `../../../assets/img/team/profile.jpg` for both `image` fields.
+
+### Moving a team member to past
+
+Move their `.qmd` file from `content/team/current/` to `content/team/past/`.
+No other changes are required as the listing pages pick up team members by
+directory.
+
+## Deployment
+
+The site is rendered and deployed automatically via GitHub Actions on push to
+the `main` branch. The rendered site is published to the `gh-pages` branch.
+
+To test changes locally before committing, run `quarto render` in the
+repository root.

--- a/_README_dev.md
+++ b/_README_dev.md
@@ -21,15 +21,16 @@ title: "Your Event Title"
 date: "YYYY-MM-DD"
 
 event:
-  date: "Dayname Day Month, Year"
-  time: "12:00 pm - 1:00 pm GMT"  # insert correct time as appropriate
+  date: "Day-name Day Month, Year"
+  time: "12:00 pm - 1:00 pm GMT"   # insert correct time as appropriate
   summary: "Short event summary"
-  location: "Room name"
-  location_url: "https://..."
-  hybrid: true
-  online_only: false
-  hybrid_url: "https://teams.microsoft.com/..."
-  meetup_url: "https://www.meetup.com/..."
+  location: "Room name"   # or leave empty as appropriate
+  venue_url: "https://..."   # or leave empty as appropriate
+  event_mode: "hybrid" | "online-only" | "in-person"
+  join_url: "https://teams.microsoft.com/..."   # or leave empty as appropriate
+  registration_url: "https://www.meetup.com/..."
+
+# chair:
 
 talk:
   speaker_1: "Speaker Name"

--- a/_README_dev.md
+++ b/_README_dev.md
@@ -1,0 +1,52 @@
+# Developer README
+
+## Event content pre- and post-migration to Quarto
+
+Past events currently support two metadata styles:
+
+- Legacy pages (2023-04-27 to 2025-02-27) use `title` and `subtitle` display
+  strings.
+- Structured pages (2025-05-22 onward) use nested `event`, `talk`, `bio`, and
+  `content` metadata.
+
+Both styles are intentionally supported for backward compatibility.
+
+## Creating a new event page
+
+To create a new page in `content/events/upcoming/`, use the following template:
+
+```yaml
+---
+title: "Your Event Title"
+date: "YYYY-MM-DD"
+
+event:
+  date: "Dayname Day Month, Year"
+  time: "12:00 pm - 1:00 pm GMT"  # insert correct time as appropriate
+  summary: "Short event summary"
+  location: "Room name"
+  location_url: "https://..."
+  hybrid: true
+  online_only: false
+  hybrid_url: "https://teams.microsoft.com/..."
+  meetup_url: "https://www.meetup.com/..."
+
+talk:
+  speaker_1: "Speaker Name"
+  topic_1: "Talk title"
+
+bio:
+  speaker_1: |
+    Speaker bio
+
+content:
+  speaker_1: |
+    Talk abstract
+---
+
+{{< include ../_event-detail-component.qmd >}}
+```
+
+The `_event-detail-component.qmd` component renders event metadata, i.e. the
+summary/date/location, conditional Meetup text, talk title, abstract and speaker
+bio.

--- a/content/events/_construct-event-location.lua
+++ b/content/events/_construct-event-location.lua
@@ -15,7 +15,11 @@ function Meta(meta)
   end
 
   local location_txt = as_text(meta.event.location)
-  local location_url = as_text(meta.event.location_url)
+  -- Prefer venue_url; fall back to location_url for backwards compatibility.
+  local venue_url = as_text(meta.event.venue_url)
+  if venue_url == "" then
+    venue_url = as_text(meta.event.location_url)
+  end
   -- Prefer event_mode; fall back to legacy booleans for backwards compatibility.
   local event_mode = as_text(meta.event.event_mode)
   if event_mode == "" then
@@ -28,7 +32,14 @@ function Meta(meta)
     end
   end
   local is_online = event_mode == "hybrid" or event_mode == "online-only"
-  local hybrid_url = as_text(meta.event.hybrid_url)
+  -- Prefer join_url; fall back to online_url, then hybrid_url for backwards compatibility.
+  local join_url = as_text(meta.event.join_url)
+  if join_url == "" then
+    join_url = as_text(meta.event.online_url)
+  end
+  if join_url == "" then
+    join_url = as_text(meta.event.hybrid_url)
+  end
   local online_txt = "Online via Microsoft Teams"
 
   local location_display = location_txt
@@ -41,13 +52,13 @@ function Meta(meta)
   end
 
   local location_link_txt = location_txt
-  if location_url ~= "" and location_txt ~= "" then
-    location_link_txt = string.format("[%s](%s)", location_txt, location_url)
+  if venue_url ~= "" and location_txt ~= "" then
+    location_link_txt = string.format("[%s](%s)", location_txt, venue_url)
   end
 
   local online_link_txt = online_txt
-  if hybrid_url ~= "" then
-    online_link_txt = string.format("[%s](%s)", online_txt, hybrid_url)
+  if join_url ~= "" then
+    online_link_txt = string.format("[%s](%s)", online_txt, join_url)
   end
 
   local location_link = location_link_txt

--- a/content/events/_construct-event-location.lua
+++ b/content/events/_construct-event-location.lua
@@ -16,12 +16,23 @@ function Meta(meta)
 
   local location_txt = as_text(meta.event.location)
   local location_url = as_text(meta.event.location_url)
-  local is_hybrid = meta.event.hybrid == true
+  -- Prefer event_mode; fall back to legacy booleans for backwards compatibility.
+  local event_mode = as_text(meta.event.event_mode)
+  if event_mode == "" then
+    if meta.event.online_only == true then
+      event_mode = "online-only"
+    elseif meta.event.hybrid == true then
+      event_mode = "hybrid"
+    else
+      event_mode = "in-person"
+    end
+  end
+  local is_online = event_mode == "hybrid" or event_mode == "online-only"
   local hybrid_url = as_text(meta.event.hybrid_url)
   local online_txt = "Online via Microsoft Teams"
 
   local location_display = location_txt
-  if is_hybrid then
+  if is_online then
     if location_txt ~= "" then
       location_display = string.format("%s • %s", location_txt, online_txt)
     else
@@ -40,7 +51,7 @@ function Meta(meta)
   end
 
   local location_link = location_link_txt
-  if is_hybrid then
+  if is_online then
     if location_link_txt ~= "" then
       location_link = string.format("%s [&#8226;]{.sep} %s", location_link_txt, online_link_txt)
     else

--- a/content/events/_construct-event-location.lua
+++ b/content/events/_construct-event-location.lua
@@ -1,49 +1,58 @@
--- Construct a location label, possibly with a link to a meeting location, as
--- well as a link to a Teams meeeting (if the URLs are provided in the metadata)
--- and add it to the event metadata
-function Meta(meta)
+-- Construct event location metadata for both listing cards and event detail
+-- pages. For listing cards we provide plain text; for detail pages we provide
+-- a markdown link variant.
 
+local function as_text(value)
+  if value == nil then
+    return ""
+  end
+  return pandoc.utils.stringify(value)
+end
+
+function Meta(meta)
   if not meta.event then
     return meta
   end
 
-  local loc_link_txt = pandoc.utils.stringify(meta.event.location or "")
+  local location_txt = as_text(meta.event.location)
+  local location_url = as_text(meta.event.location_url)
   local is_hybrid = meta.event.hybrid == true
-  local loc_url = meta.event.location_url and pandoc.utils.stringify(meta.event.location_url) or nil
-  local hybrid_url = meta.event.hybrid_url and pandoc.utils.stringify(meta.event.hybrid_url) or nil
+  local hybrid_url = as_text(meta.event.hybrid_url)
+  local online_txt = "Online via Microsoft Teams"
 
-  -- If there's a URL, create a markdown link
-  if loc_url then
-    loc_link_txt = string.format("[%s](%s)", loc_link_txt, loc_url)
-  end
-
-  -- Compose label:
-  --   plain "<location>" or "<location> • Online via Microsoft Teams"
-  -- The location could be a link to a meeting location, and the online link
-  -- could be a link to a Teams meeting (if the URLs are provided in the
-  -- metadata)
-
-  local online_link = "Online via Microsoft Teams"
-
-  local loc_link
+  local location_display = location_txt
   if is_hybrid then
-    -- If there's a URL, create a markdown link
-    if hybrid_url then
-      online_link = string.format("[%s](%s)", online_link, hybrid_url)
-    end
-    if loc_link_txt ~= "" then
-      loc_link = string.format("%s [&#8226;]{.sep} %s", loc_link_txt, online_link)
+    if location_txt ~= "" then
+      location_display = string.format("%s • %s", location_txt, online_txt)
     else
-      loc_link = online_link
+      location_display = online_txt
     end
-  else
-    loc_link = loc_link_txt
   end
 
-  -- Add the location link to the event metadata
-  -- Note that it may not be an actual link (if no url is provided in the
-  -- metadata)
-  meta.event["location-link"] = pandoc.MetaInlines(pandoc.read(loc_link, "markdown").blocks[1].content)
+  local location_link_txt = location_txt
+  if location_url ~= "" and location_txt ~= "" then
+    location_link_txt = string.format("[%s](%s)", location_txt, location_url)
+  end
+
+  local online_link_txt = online_txt
+  if hybrid_url ~= "" then
+    online_link_txt = string.format("[%s](%s)", online_txt, hybrid_url)
+  end
+
+  local location_link = location_link_txt
+  if is_hybrid then
+    if location_link_txt ~= "" then
+      location_link = string.format("%s [&#8226;]{.sep} %s", location_link_txt, online_link_txt)
+    else
+      location_link = online_link_txt
+    end
+  end
+
+  meta.event["location_display"] = pandoc.MetaString(location_display)
+  meta.event["location-display"] = pandoc.MetaString(location_display)
+  meta.event["location-link"] = pandoc.MetaInlines(
+    pandoc.read(location_link, "markdown").blocks[1].content
+  )
 
   return meta
 end

--- a/content/events/_construct-event-location.lua
+++ b/content/events/_construct-event-location.lua
@@ -15,31 +15,13 @@ function Meta(meta)
   end
 
   local location_txt = as_text(meta.event.location)
-  -- Prefer venue_url; fall back to location_url for backwards compatibility.
   local venue_url = as_text(meta.event.venue_url)
-  if venue_url == "" then
-    venue_url = as_text(meta.event.location_url)
-  end
-  -- Prefer event_mode; fall back to legacy booleans for backwards compatibility.
   local event_mode = as_text(meta.event.event_mode)
   if event_mode == "" then
-    if meta.event.online_only == true then
-      event_mode = "online-only"
-    elseif meta.event.hybrid == true then
-      event_mode = "hybrid"
-    else
-      event_mode = "in-person"
-    end
+    event_mode = "in-person"
   end
   local is_online = event_mode == "hybrid" or event_mode == "online-only"
-  -- Prefer join_url; fall back to online_url, then hybrid_url for backwards compatibility.
   local join_url = as_text(meta.event.join_url)
-  if join_url == "" then
-    join_url = as_text(meta.event.online_url)
-  end
-  if join_url == "" then
-    join_url = as_text(meta.event.hybrid_url)
-  end
   local online_txt = "Online via Microsoft Teams"
 
   local location_display = location_txt

--- a/content/events/_construct-event-meetup.lua
+++ b/content/events/_construct-event-meetup.lua
@@ -13,23 +13,12 @@ function Meta(meta)
     return meta
   end
 
-  -- Prefer registration_url; fall back to meetup_url for backwards compatibility.
   local registration_url = as_text(meta.event.registration_url)
-  if registration_url == "" then
-    registration_url = as_text(meta.event.meetup_url)
-  end
   local has_meetup_link = registration_url ~= ""
 
-  -- Prefer event_mode; fall back to legacy booleans for backwards compatibility.
   local event_mode = as_text(meta.event.event_mode)
   if event_mode == "" then
-    if meta.event.online_only == true then
-      event_mode = "online-only"
-    elseif meta.event.hybrid == true then
-      event_mode = "hybrid"
-    else
-      event_mode = "in-person"
-    end
+    event_mode = "in-person"
   end
 
   local meetup_label = "If you plan on attending in person, please"

--- a/content/events/_construct-event-meetup.lua
+++ b/content/events/_construct-event-meetup.lua
@@ -16,8 +16,20 @@ function Meta(meta)
   local meetup_url = as_text(meta.event.meetup_url)
   local has_meetup_link = meetup_url ~= ""
 
+  -- Prefer event_mode; fall back to legacy booleans for backwards compatibility.
+  local event_mode = as_text(meta.event.event_mode)
+  if event_mode == "" then
+    if meta.event.online_only == true then
+      event_mode = "online-only"
+    elseif meta.event.hybrid == true then
+      event_mode = "hybrid"
+    else
+      event_mode = "in-person"
+    end
+  end
+
   local meetup_label = "If you plan on attending in person, please"
-  if meta.event.online_only == true then
+  if event_mode == "online-only" then
     meetup_label = "If you plan on attending, please"
   end
 

--- a/content/events/_construct-event-meetup.lua
+++ b/content/events/_construct-event-meetup.lua
@@ -13,8 +13,12 @@ function Meta(meta)
     return meta
   end
 
-  local meetup_url = as_text(meta.event.meetup_url)
-  local has_meetup_link = meetup_url ~= ""
+  -- Prefer registration_url; fall back to meetup_url for backwards compatibility.
+  local registration_url = as_text(meta.event.registration_url)
+  if registration_url == "" then
+    registration_url = as_text(meta.event.meetup_url)
+  end
+  local has_meetup_link = registration_url ~= ""
 
   -- Prefer event_mode; fall back to legacy booleans for backwards compatibility.
   local event_mode = as_text(meta.event.event_mode)
@@ -35,7 +39,7 @@ function Meta(meta)
 
   local meetup_link = pandoc.MetaInlines(pandoc.Str(""))
   if has_meetup_link then
-    local meetup_txt = string.format("%s [register on Meetup](%s)", meetup_label, meetup_url)
+    local meetup_txt = string.format("%s [register on Meetup](%s)", meetup_label, registration_url)
     meetup_link = pandoc.MetaInlines(pandoc.read(meetup_txt, "markdown").blocks[1].content)
   end
 

--- a/content/events/_construct-event-meetup.lua
+++ b/content/events/_construct-event-meetup.lua
@@ -1,37 +1,33 @@
--- Construct a link to a Meetup event, if the URL is provided in the metadata
--- (or a blank string), and add it to the event metadata
-function Meta(meta)
+-- Construct a Meetup link for event detail pages and a boolean availability
+-- flag for deterministic conditional rendering.
 
+local function as_text(value)
+  if value == nil then
+    return ""
+  end
+  return pandoc.utils.stringify(value)
+end
+
+function Meta(meta)
   if not meta.event then
     return meta
   end
 
-  local meetup_url = meta.event.meetup_url and pandoc.utils.stringify(meta.event.meetup_url) or nil
+  local meetup_url = as_text(meta.event.meetup_url)
+  local has_meetup_link = meetup_url ~= ""
 
-  local meetup_label = ""
-  if meta.event and meta.event.online_only then
+  local meetup_label = "If you plan on attending in person, please"
+  if meta.event.online_only == true then
     meetup_label = "If you plan on attending, please"
-  else
-    meetup_label = "If you plan on attending in person, please"
   end
 
-  local meetup_link_txt = "register on Meetup"
-
-  local has_meetup_link
-  local meetup_link
-  if meetup_url then
-    has_meetup_link = true
-    meetup_link = string.format("%s [%s](%s)", meetup_label, meetup_link_txt, meetup_url)
-    meetup_link = pandoc.MetaInlines(pandoc.read(meetup_link, "markdown").blocks[1].content)
-  else
-    has_meetup_link = false
-    meetup_link = pandoc.MetaInlines(pandoc.Str(""))
+  local meetup_link = pandoc.MetaInlines(pandoc.Str(""))
+  if has_meetup_link then
+    local meetup_txt = string.format("%s [register on Meetup](%s)", meetup_label, meetup_url)
+    meetup_link = pandoc.MetaInlines(pandoc.read(meetup_txt, "markdown").blocks[1].content)
   end
 
-  -- Add the meetup link status (true/false) to the event metadata
-  meta.event["has-meetup-link"] = has_meetup_link
-
-  -- Add the meetup link (possibly a blank string) to the event metadata
+  meta.event["has-meetup-link"] = pandoc.MetaBool(has_meetup_link)
   meta.event["meetup-link"] = meetup_link
 
   return meta

--- a/content/events/_event-detail-component.qmd
+++ b/content/events/_event-detail-component.qmd
@@ -1,0 +1,19 @@
+<!-- *** Note *** -->
+<!-- Dynamically constructed links: -->
+<!-- 1. meta event.location-link is constructed in content/events/_construct-event-location.lua -->
+<!-- 2. meta event.meetup-link is constructed in content/events/_construct-event-meetup.lua -->
+
+[{{< meta event.summary >}}]{.event-summary} \
+[{{< meta event.date >}} @ {{< meta event.time >}}]{.event-time} \
+[{{< meta event.location-link >}}]{.event-location}
+
+::: {when-meta="event.has-meetup-link"}
+[{{< meta event.meetup-link >}}]{.event-meetup}
+:::
+
+**Talk**: *{{< meta talk.topic_1 >}}*
+
+{{< meta content.speaker_1 >}}
+
+**Speaker**: *{{< meta talk.speaker_1 >}}* \
+{{< meta bio.speaker_1 >}}

--- a/content/events/_event-listing.ejs
+++ b/content/events/_event-listing.ejs
@@ -5,7 +5,7 @@
     let locationDisplay = '';
     if (event) {
       const baseLocation = event.location || '';
-      const effectiveMode = event.event_mode || (event.online_only ? 'online-only' : (event.hybrid ? 'hybrid' : 'in-person'));
+      const effectiveMode = event.event_mode || 'in-person';
       if (effectiveMode === 'hybrid' || effectiveMode === 'online-only') {
         if (effectiveMode === 'online-only' || baseLocation === '') {
           locationDisplay = 'Online via Microsoft Teams';

--- a/content/events/_event-listing.ejs
+++ b/content/events/_event-listing.ejs
@@ -5,8 +5,9 @@
     let locationDisplay = '';
     if (event) {
       const baseLocation = event.location || '';
-      if (event.hybrid) {
-        if (event.online_only || baseLocation === '') {
+      const effectiveMode = event.event_mode || (event.online_only ? 'online-only' : (event.hybrid ? 'hybrid' : 'in-person'));
+      if (effectiveMode === 'hybrid' || effectiveMode === 'online-only') {
+        if (effectiveMode === 'online-only' || baseLocation === '') {
           locationDisplay = 'Online via Microsoft Teams';
         } else {
           locationDisplay = baseLocation + ' [&#8226;]{.sep} Online via Microsoft Teams';

--- a/content/events/_event-listing.ejs
+++ b/content/events/_event-listing.ejs
@@ -1,3 +1,8 @@
+<% if (items.length === 0) { %>
+  <% if (templateParams && templateParams['empty-message']) { %>
+<p><%= templateParams['empty-message'] %></p>
+  <% } %>
+<% } else { %>
 <div class="list-entry">
 <% for (const item of items) { %>
   <%
@@ -27,3 +32,4 @@
   </a></div></div>
 <% } %>
 </div>
+<% } %>

--- a/content/events/_event-listing.ejs
+++ b/content/events/_event-listing.ejs
@@ -1,21 +1,28 @@
 <div class="list-entry">
 <% for (const item of items) { %>
   <%
-    var hybrid_lbl = ""
-    if (item.event && item.event.hybrid) {
-      if (item.event.online_only) {
-        hybrid_lbl = "Online via Microsoft Teams"
+    const event = item.event || null;
+    let locationDisplay = '';
+    if (event) {
+      const baseLocation = event.location || '';
+      if (event.hybrid) {
+        if (event.online_only || baseLocation === '') {
+          locationDisplay = 'Online via Microsoft Teams';
+        } else {
+          locationDisplay = baseLocation + ' [&#8226;]{.sep} Online via Microsoft Teams';
+        }
       } else {
-        hybrid_lbl = "&nbsp;[&#8226;]{.sep} Online via Microsoft Teams"
+        locationDisplay = baseLocation;
       }
     }
-  %><div>
+  %>
+  <div>
   <div class="listing-col1 event-date"><%= (item.event && item.event.date) || item.date %></div>
   <div class="listing-col2 event-descrip"><a href="<%- item.path %>">
     <span class="event-title"><%= item.title %></span> <br/>
     <span class="event-summary"><%= (item.event && item.event.summary) || item.subtitle %></span> <br/>
     <span class="event-time"><%= item.event && (item.event.date + ' @ ') %><%= item.event && item.event.time %></span> <br/>
-    <span class="event-location"><%= item.event && item.event.location %><%= hybrid_lbl %></span>
+    <span class="event-location"><%= locationDisplay %></span>
   </a></div></div>
 <% } %>
 </div>

--- a/content/events/index.qmd
+++ b/content/events/index.qmd
@@ -21,9 +21,14 @@ listing:
     template: _event-listing.ejs
     contents:
       - past/*.qmd
-    # TODO: Remove this once past events have been converted to ejs template
-    # type: default
-    # fields: [date, title]
+    # Temporary compatibility fallback for legacy event pages that do not yet
+    # use the new 'event:' metadata block (i.e. event pages up to 2025-02-27).
+    # The listing template in content/events/_event-listing.ejs falls back to
+    # the top-level title/subtitle/date fields when an 'event:' block is absent.
+    # This fallback can be removed once all event pages have been migrated to
+    # the new 'event:' structure. At that point, the 'sort:' rule should also be
+    # reviewed and adjusted if you want the listing to order items using the new
+    # event-based metadata structure.
     sort:
       - "date desc"
       - "title"

--- a/content/events/index.qmd
+++ b/content/events/index.qmd
@@ -13,6 +13,8 @@ listing:
     template: _event-listing.ejs
     contents:
       - upcoming/*.qmd
+    template-params:
+      empty-message: "We don't currently have any scheduled events &#8230; please check back."
     sort:
       - "date desc"
       - "title"
@@ -33,18 +35,9 @@ listing:
       - "date desc"
       - "title"
 
-events:
-  # Set meta events.upcoming to true/false according to whether there are any events to display
-  upcoming: true
 ---
 
-[comment]: # (NB: Set meta events.upcoming to true/false according to whether there are any events to display)
-
 ### Upcoming
-
-::: {.content-hidden when-meta="events.upcoming"}
-We don't currently have any scheduled events &#8230; please check back
-:::
 
 :::{#events-upcoming}
 :::

--- a/content/events/past/2025-05-22_building-r-packages.qmd
+++ b/content/events/past/2025-05-22_building-r-packages.qmd
@@ -43,28 +43,4 @@ content:
     R skills to the next level!
 ---
 
-<!-- *** Note *** -->
-<!-- Dynamically constructed links: -->
-<!-- 1. meta event.location-link is constructed in content/events/_construct-event-location.lua -->
-<!-- 2. meta event.meetup-link is constructed in content/events/_construct-event-meetup.lua -->
-
-[{{< meta event.summary >}}]{.event-summary} \
-[{{< meta event.date >}} @ {{< meta event.time >}}]{.event-time} \
-[{{< meta event.location-link >}}]{.event-location}
-
-<!-- The following content will only be rendered if -->
-<!-- meta event.has-meetup-link is true -->
-<!-- Note: This is currently not working and is rendering in the opposite -->
-<!-- way from what is expected ... so comment out the conditional logic for -->
-<!-- now pending further investigation! (meta event.meetup-link will be an -->
-<!-- empty string if the url is not provided) -->
-<!-- ::: {.content-hidden unless-meta="event.has-meetup-link"} -->
-[{{< meta event.meetup-link >}}]{.event-meetup}
-<!-- ::: -->
-
-**Talk**: *{{< meta talk.topic_1 >}}*
-
-{{< meta content.speaker_1 >}}
-
-**Speaker**: *{{< meta talk.speaker_1 >}}* \
-{{< meta bio.speaker_1 >}}
+{{< include ../_event-detail-component.qmd >}}

--- a/content/events/past/2025-05-22_building-r-packages.qmd
+++ b/content/events/past/2025-05-22_building-r-packages.qmd
@@ -13,10 +13,10 @@ event:
   summary: "Toni Price demonstrates how to build a simple R package
     (the easy way)."
   location: "Hanson Room, Humanities Bridgeford Street (UoM)"
-  location_url: "https://www.estates.manchester.ac.uk/services/centralteachingspaces/ourservices/roomcatalogue/?building=15&room=75"
+  venue_url: "https://www.estates.manchester.ac.uk/services/centralteachingspaces/ourservices/roomcatalogue/?building=15&room=75"
   event_mode: "hybrid"
-  hybrid_url: "https://teams.microsoft.com/l/meetup-join/19%3a7067cf1044b243a4a548d19ef38dd4ca%40thread.tacv2/1741775644013?context=%7b%22Tid%22%3a%22c152cb07-614e-4abb-818a-f035cfa91a77%22%2c%22Oid%22%3a%22a6268e3e-ebaf-4ac7-8498-8dbd4e1c426a%22%7d"
-  meetup_url: "https://www.meetup.com/r-users-group-uni-manchester/events/307599485/?utm_medium=referral&utm_campaign=share-btn_savedevents_share_modal&utm_source=link"
+  join_url: "https://teams.microsoft.com/l/meetup-join/19%3a7067cf1044b243a4a548d19ef38dd4ca%40thread.tacv2/1741775644013?context=%7b%22Tid%22%3a%22c152cb07-614e-4abb-818a-f035cfa91a77%22%2c%22Oid%22%3a%22a6268e3e-ebaf-4ac7-8498-8dbd4e1c426a%22%7d"
+  registration_url: "https://www.meetup.com/r-users-group-uni-manchester/events/307599485/?utm_medium=referral&utm_campaign=share-btn_savedevents_share_modal&utm_source=link"
 
 # chair:
 

--- a/content/events/past/2025-05-22_building-r-packages.qmd
+++ b/content/events/past/2025-05-22_building-r-packages.qmd
@@ -14,7 +14,7 @@ event:
     (the easy way)."
   location: "Hanson Room, Humanities Bridgeford Street (UoM)"
   location_url: "https://www.estates.manchester.ac.uk/services/centralteachingspaces/ourservices/roomcatalogue/?building=15&room=75"
-  hybrid: true
+  event_mode: "hybrid"
   hybrid_url: "https://teams.microsoft.com/l/meetup-join/19%3a7067cf1044b243a4a548d19ef38dd4ca%40thread.tacv2/1741775644013?context=%7b%22Tid%22%3a%22c152cb07-614e-4abb-818a-f035cfa91a77%22%2c%22Oid%22%3a%22a6268e3e-ebaf-4ac7-8498-8dbd4e1c426a%22%7d"
   meetup_url: "https://www.meetup.com/r-users-group-uni-manchester/events/307599485/?utm_medium=referral&utm_campaign=share-btn_savedevents_share_modal&utm_source=link"
 

--- a/content/events/past/2025-10-09_random-forest.qmd
+++ b/content/events/past/2025-10-09_random-forest.qmd
@@ -13,10 +13,10 @@ event:
   summary: "Chris Bowden covers everything you need to start running your own
     Random Forest models in R."
   location: "Nancy Rothwell GA.056"
-  location_url: "https://clients.mapsindoors.com/uniofmanchester/f02513f6650e4646ae55c607/details/e879f84107154389a73da0fe"
+  venue_url: "https://clients.mapsindoors.com/uniofmanchester/f02513f6650e4646ae55c607/details/e879f84107154389a73da0fe"
   event_mode: "hybrid"
-  hybrid_url: "https://teams.microsoft.com/l/meetup-join/19%3a7067cf1044b243a4a548d19ef38dd4ca%40thread.tacv2/1751884343074?context=%7b%22Tid%22%3a%22c152cb07-614e-4abb-818a-f035cfa91a77%22%2c%22Oid%22%3a%22a6268e3e-ebaf-4ac7-8498-8dbd4e1c426a%22%7d"
-  meetup_url: "https://www.meetup.com/r-users-group-uni-manchester/events/308963404/?utm_medium=referral&utm_campaign=share-btn_savedevents_share_modal&utm_source=link"
+  join_url: "https://teams.microsoft.com/l/meetup-join/19%3a7067cf1044b243a4a548d19ef38dd4ca%40thread.tacv2/1751884343074?context=%7b%22Tid%22%3a%22c152cb07-614e-4abb-818a-f035cfa91a77%22%2c%22Oid%22%3a%22a6268e3e-ebaf-4ac7-8498-8dbd4e1c426a%22%7d"
+  registration_url: "https://www.meetup.com/r-users-group-uni-manchester/events/308963404/?utm_medium=referral&utm_campaign=share-btn_savedevents_share_modal&utm_source=link"
 
 # chair:
 

--- a/content/events/past/2025-10-09_random-forest.qmd
+++ b/content/events/past/2025-10-09_random-forest.qmd
@@ -14,7 +14,7 @@ event:
     Random Forest models in R."
   location: "Nancy Rothwell GA.056"
   location_url: "https://clients.mapsindoors.com/uniofmanchester/f02513f6650e4646ae55c607/details/e879f84107154389a73da0fe"
-  hybrid: true
+  event_mode: "hybrid"
   hybrid_url: "https://teams.microsoft.com/l/meetup-join/19%3a7067cf1044b243a4a548d19ef38dd4ca%40thread.tacv2/1751884343074?context=%7b%22Tid%22%3a%22c152cb07-614e-4abb-818a-f035cfa91a77%22%2c%22Oid%22%3a%22a6268e3e-ebaf-4ac7-8498-8dbd4e1c426a%22%7d"
   meetup_url: "https://www.meetup.com/r-users-group-uni-manchester/events/308963404/?utm_medium=referral&utm_campaign=share-btn_savedevents_share_modal&utm_source=link"
 

--- a/content/events/past/2025-10-09_random-forest.qmd
+++ b/content/events/past/2025-10-09_random-forest.qmd
@@ -17,6 +17,7 @@ event:
   hybrid: true
   hybrid_url: "https://teams.microsoft.com/l/meetup-join/19%3a7067cf1044b243a4a548d19ef38dd4ca%40thread.tacv2/1751884343074?context=%7b%22Tid%22%3a%22c152cb07-614e-4abb-818a-f035cfa91a77%22%2c%22Oid%22%3a%22a6268e3e-ebaf-4ac7-8498-8dbd4e1c426a%22%7d"
   meetup_url: "https://www.meetup.com/r-users-group-uni-manchester/events/308963404/?utm_medium=referral&utm_campaign=share-btn_savedevents_share_modal&utm_source=link"
+
 # chair:
 
 talk:
@@ -49,28 +50,4 @@ content:
     machine learning with confidence!
 ---
 
-<!-- *** Note *** -->
-<!-- Dynamically constructed links: -->
-<!-- 1. meta event.location-link is constructed in content/events/_construct-event-location.lua -->
-<!-- 2. meta event.meetup-link is constructed in content/events/_construct-event-meetup.lua -->
-
-[{{< meta event.summary >}}]{.event-summary} \
-[{{< meta event.date >}} @ {{< meta event.time >}}]{.event-time} \
-[{{< meta event.location-link >}}]{.event-location}
-
-<!-- The following content will only be rendered if -->
-<!-- meta event.has-meetup-link is true -->
-<!-- Note: This is currently not working and is rendering in the opposite -->
-<!-- way from what is expected ... so comment out the conditional logic for -->
-<!-- now pending further investigation! (meta event.meetup-link will be an -->
-<!-- empty string if the url is not provided) -->
-<!-- ::: {.content-hidden unless-meta="event.has-meetup-link"} -->
-[{{< meta event.meetup-link >}}]{.event-meetup}
-<!-- ::: -->
-
-**Talk**: *{{< meta talk.topic_1 >}}*
-
-{{< meta content.speaker_1 >}}
-
-**Speaker**: *{{< meta talk.speaker_1 >}}* \
-{{< meta bio.speaker_1 >}}
+{{< include ../_event-detail-component.qmd >}}

--- a/content/events/past/2026-03-26_stand-out-visualisations-in-r.qmd
+++ b/content/events/past/2026-03-26_stand-out-visualisations-in-r.qmd
@@ -13,10 +13,10 @@ event:
   summary: "We are delighted to welcome invited speaker Cara Thompson on tips
     and tricks for effortless stand-out visualisations in R."
   # location: ""
-  # location_url: ""
+  # venue_url: ""
   event_mode: "online-only"
-  hybrid_url: "https://teams.microsoft.com/meet/39698534105343?p=fApHtgURWxJLOmTJD2"
-  meetup_url: "https://www.meetup.com/r-users-group-uni-manchester/events/313172815/"
+  join_url: "https://teams.microsoft.com/meet/39698534105343?p=fApHtgURWxJLOmTJD2"
+  registration_url: "https://www.meetup.com/r-users-group-uni-manchester/events/313172815/"
 
 # chair:
 

--- a/content/events/past/2026-03-26_stand-out-visualisations-in-r.qmd
+++ b/content/events/past/2026-03-26_stand-out-visualisations-in-r.qmd
@@ -14,10 +14,10 @@ event:
     and tricks for effortless stand-out visualisations in R."
   # location: ""
   # location_url: ""
-  online_only: true
-  hybrid: true
+  event_mode: "online-only"
   hybrid_url: "https://teams.microsoft.com/meet/39698534105343?p=fApHtgURWxJLOmTJD2"
   meetup_url: "https://www.meetup.com/r-users-group-uni-manchester/events/313172815/"
+
 # chair:
 
 talk:

--- a/content/events/past/2026-03-26_stand-out-visualisations-in-r.qmd
+++ b/content/events/past/2026-03-26_stand-out-visualisations-in-r.qmd
@@ -33,7 +33,7 @@ bio:
     services include a combination of training, dataviz toolkits such as bespoke
     R packages, and dataviz commissions. She is an active member of the online
     RStats community, and enjoys learning out loud and experimenting with new
-    ideas. 
+    ideas.
 
 content:
   speaker_1: |
@@ -48,28 +48,4 @@ content:
     session.
 ---
 
-<!-- *** Note *** -->
-<!-- Dynamically constructed links: -->
-<!-- 1. meta event.location-link is constructed in content/events/_construct-event-location.lua -->
-<!-- 2. meta event.meetup-link is constructed in content/events/_construct-event-meetup.lua -->
-
-[{{< meta event.summary >}}]{.event-summary} \
-[{{< meta event.date >}} @ {{< meta event.time >}}]{.event-time} \
-[{{< meta event.location-link >}}]{.event-location}
-
-<!-- The following content will only be rendered if -->
-<!-- meta event.has-meetup-link is true -->
-<!-- Note: This is currently not working and is rendering in the opposite -->
-<!-- way from what is expected ... so comment out the conditional logic for -->
-<!-- now pending further investigation! (meta event.meetup-link will be an -->
-<!-- empty string if the url is not provided) -->
-<!-- ::: {.content-hidden unless-meta="event.has-meetup-link"} -->
-[{{< meta event.meetup-link >}}]{.event-meetup}
-<!-- ::: -->
-
-**Talk**: *{{< meta talk.topic_1 >}}*
-
-{{< meta content.speaker_1 >}}
-
-**Speaker**: *{{< meta talk.speaker_1 >}}* \
-{{< meta bio.speaker_1 >}}
+{{< include ../_event-detail-component.qmd >}}

--- a/content/events/upcoming/2026-09-24_git_and_github_in_rstudio.qmd
+++ b/content/events/upcoming/2026-09-24_git_and_github_in_rstudio.qmd
@@ -2,7 +2,7 @@
 title: "Working with Git and GitHub in RStudio"
 
 # Publication date of this entry
-date: "2026-09-24"
+date: "2026-08-10"
 
 event:
   date: "Thu 24 September, 2026"
@@ -12,12 +12,12 @@ event:
   time: "12:00 pm - 1:00 pm BST"
   summary: "A practical introduction to version control from within RStudio
     to support reproducible and collaborative data science."
-  location: "University of Manchester, room TBD "
-  # location_url: ""
-  online_only: true
-  hybrid: true
-  hybrid_url: "https://teams.microsoft.com/meet/314142607894094?p=RwXbgaz2IsQb69cAOR"
-  meetup_url: "https://www.meetup.com/r-users-group-uni-manchester/events/315904515/"
+  location: "University of Manchester, room TBD"
+  # venue_url: ""
+  event_mode: "hybrid"
+  join_url: "https://teams.microsoft.com/meet/314142607894094?p=RwXbgaz2IsQb69cAOR"
+  registration_url: "https://www.meetup.com/r-users-group-uni-manchester/events/315904515/"
+
 # chair:
 
 talk:


### PR DESCRIPTION
### Motivation

The Quarto event-listing metadata had evolved organically and become harder to maintain, so this PR simplifies and standardises that structure. It also reduces duplication across event pages by introducing a shared component template for common event content.

### Changes

- Adds a Quarto content template
  - Moves event listing content into a shared template
  - Makes lua metadata filtering more consistent
  - Makes`.ejs` template code clearer

- Creates a metdata 'enum' style variable `'event_mode'`
  - Consolidates `event.hybrid` and `event.online_only` into a single `event.event_mode` variable

- Names metadata more clearly to disambiguate and clarify it
  - Name changes:
    - `hybrid_url` -> `join_url`
    - `meetup_url` -> `registration_url`
    - `location_url` -> `venue_url`

- Eliminates the need to specify the `events.upcoming` metadata variable
   - Previously it was necessary to specify `events.upcoming` as `true` or `false` depending on whether there were any upcoming events
   - This PR reduces redundancy & potential error by moving the related logic into the `.ejs` template and removing the `events.upcoming` variable

- Adds developer documentation in `_README_dev.md`
  - Sections include:
    - Managing upcoming/past events
    - Managing team members
    - Deployment
